### PR TITLE
Enhanced Configurability with Environment Variables 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 # Bulk SMS Sender
 
 ## About
-Bulk SMS Sender is a web-based app that uses a Twilio account to send SMS messages in bulk from a CSV file.
+Bulk SMS Sender is a web-based app that uses a Twilio account to send SMS messages in bulk from a CSV file. The CSV file can be uploaded via a web form or fetched from a provided URL. 
 
 ## Usage
-The user saves the data on a CSV file with 3 columns and use a webform to update the CSV file with their Twilio credentials. The backend uses
-Twilio's Python SDK to send the messages and generate a delivery report.
+The user inputs their Twilio credentials and either uploads a CSV file or provides a CSV URL via a webform. The backend uses Twilio's Python SDK to send the messages and generate a delivery report.
+
+## Configurability
+The Twilio credentials and CSV URL can be preset using the following environment variables: `TWILIO_SID`, `TWILIO_TOKEN`, and `CSV_URL`. If these are set, their values will be used as defaults in the web form. 
 
 ## Tech stack
 - Python 3.9 - 3.11
@@ -25,7 +27,9 @@ Twilio's Python SDK to send the messages and generate a delivery report.
 
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/RAHB-REALTORS-Association/sms-sender/tree/master)
 
-Review settings.py before deployment, especially the following settings:
+Review `settings.py` before deployment, especially the following settings:
 - Line 2: Testing
 - Line 3: Flask secret. Generate a random Secret on deployment
 - Line 6: Set the upload folder according to your OS
+
+Also remember to set the `TWILIO_SID`, `TWILIO_TOKEN`, and `CSV_URL` environment variables if you want to preset these values.

--- a/app.py
+++ b/app.py
@@ -33,17 +33,15 @@ def index():
             flash("Twilio ID and token required")
             return redirect(request.url)
 
-        sid = request.form["sid"]
-        token = request.form["token"]
+        sid = request.form.get("sid") or settings.TWILIO_SID
+        token = request.form.get("token") or settings.TWILIO_TOKEN
+        csv_url = request.form.get("csv_url") or settings.CSV_URL
 
         if not tools.valid_credentials(sid, token):
             flash("Invalid Twilio credentials. Please double check your Twilio account SID and token and try again")
             return redirect(request.url)
         
-        csv_url = request.form.get("csv_url")
         if csv_url:
- 
-
             number_list = tools.get_number_list_from_url(csv_url)
         
         else:

--- a/app.py
+++ b/app.py
@@ -29,21 +29,23 @@ def contact():
 @app.route("/", methods=["GET", "POST"])
 def index():
     if request.method == "POST":
-        if request.form["sid"] == "" or request.form["token"] == "":
-            flash("Twilio ID and token required")
-            return redirect(request.url)
-
         sid = request.form.get("sid") or settings.TWILIO_SID
         token = request.form.get("token") or settings.TWILIO_TOKEN
         csv_url = request.form.get("csv_url") or settings.CSV_URL
 
+        if sid == "" or token == "":
+            flash("Twilio ID and token required")
+            return redirect(request.url)
+
         if not tools.valid_credentials(sid, token):
             flash("Invalid Twilio credentials. Please double check your Twilio account SID and token and try again")
             return redirect(request.url)
-        
+
         if csv_url:
+            if not tools.is_valid_url(csv_url):
+                flash("Invalid CSV URL")
+                return redirect(request.url)
             number_list = tools.get_number_list_from_url(csv_url)
-        
         else:
             if "file" not in request.files:
                 flash("No file selected")
@@ -56,12 +58,7 @@ def index():
 
             if file and tools.allowed_file(file.filename):
                 filename = secure_filename(file.filename)
-                file.save(
-                    os.path.join(
-                        app.config["UPLOAD_FOLDER"],
-                        filename
-                    )
-                )
+                file.save(os.path.join(app.config["UPLOAD_FOLDER"], filename))
 
                 number_list = tools.get_number_list(filename)
                 wrong_numbers = tools.check_numbers(number_list, sid, token)
@@ -70,15 +67,18 @@ def index():
                     with open(settings.LOG_FILE, "a") as log_file:
                         log_string = f"{datetime.now()} - {len(wrong_numbers)} wrong numbers identified."
                         log_file.write(f"\n{log_string}")
-                    return render_template(
-                        "wrong_numbers.html",
-                        number_list=wrong_numbers
-                    )
+                    return render_template("wrong_numbers.html", number_list=wrong_numbers)
 
                 number_list = tools.send_messages(number_list, sid, token)
                 return render_template("report.html", number_list=number_list)
             else:
                 flash("File type not allowed. Please select a CSV file")
                 return redirect(request.url)
-
-    return render_template("index.html")
+    else:
+        token_placeholder = "••••••••••••••••••••••••••" if settings.TWILIO_TOKEN else ""
+        return render_template(
+            "index.html",
+            sid_placeholder=settings.TWILIO_SID,
+            token_placeholder=token_placeholder,
+            csv_url_placeholder=settings.CSV_URL
+        )

--- a/settings.py
+++ b/settings.py
@@ -2,6 +2,9 @@ import os
 # Flask config
 TESTING = False
 SECRET_KEY = os.environ.get('SECRET_KEY')
+TWILIO_SID = os.environ.get('TWILIO_SID', '')
+TWILIO_TOKEN = os.environ.get('TWILIO_TOKEN', '')
+CSV_URL = os.environ.get('CSV_URL', '')
 PERMANENT_SESSION_LIFETIME = 180
 JSONIFY_PRETTYPRINT_REGULAR = True
 UPLOAD_FOLDER = "/tmp"

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,14 +21,14 @@
         started!
         <div id="upload_form" class="form-inline">
             <form method="post" enctype="multipart/form-data">
-                    <div class="mt-15">
-                        <input type="text" class="form-control" placeholder="Twilio Account SID" aria-describedby="basic-addon1" name="sid" size="50">
-                    </div>
-                    <div class="mt-15">
-                        <input type="password" class="form-control" placeholder="Twilio Token" aria-describedby="basic-addon1" name="token" size="50">
-                    </div>
                 <div class="mt-15">
-                    <input type="text" class="form-control" placeholder="CSV URL" aria-describedby="basic-addon1" name="csv_url" size="50">
+                    <input type="text" class="form-control" placeholder="{{ sid_placeholder or 'Twilio Account SID' }}" aria-describedby="basic-addon1" name="sid" size="50">
+                </div>
+                <div class="mt-15">
+                    <input type="password" class="form-control" placeholder="{{ token_placeholder or 'Twilio Token' }}" aria-describedby="basic-addon1" name="token" size="50">
+                </div>
+                <div class="mt-15">
+                    <input type="text" class="form-control" placeholder="{{ csv_url_placeholder or 'CSV URL' }}" aria-describedby="basic-addon1" name="csv_url" size="50">
                 </div>                    
                 <div class="mt-15">
                     <input type="file" name="file">


### PR DESCRIPTION
This pull request includes enhancements to the Bulk SMS Sender that improve its configurability and usability:

1. **Environment Variables for Presets:** The Twilio SID, token, and CSV URL can now be preset using environment variables (`TWILIO_SID`, `TWILIO_TOKEN`, and `CSV_URL`). If these environment variables are set, their values will be used as defaults in the web form. This feature makes it easier to reuse the same credentials or CSV URL across multiple sessions.

2. **Form Placeholders for Presets:** If the environment variables for the Twilio SID and CSV URL are set, their values will be shown as placeholders in the form inputs. For the Twilio token, a series of pip symbols will be shown as a placeholder if the environment variable is set. These placeholders provide a visual indication of the preset values without revealing sensitive information.

These enhancements were implemented with a focus on improving the user experience, especially for users who frequently use the Bulk SMS Sender with the same credentials or CSV data. The README has been updated to reflect these changes.